### PR TITLE
sfneal/queueables v2.0 upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ php:
     - 7.3
     - 7.2
     - 7.1
-    - 7.0
 
 before_script:
     - echo "memory_limit=4096M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,8 @@ All notable changes to `post-office` will be documented in this file
 
 ## 0.5.1 - 2021-04-05
 - fix sfneal/queueables version constraint (^1.0)
+
+
+## 0.6.0 - 2021-04-05
+- cut support for php 7.0
+- bump min sfneal/queueables version to ^2.0

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "illuminate/support": "*",
         "sfneal/queueables": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.1",
         "illuminate/support": "*",
-        "sfneal/queueables": "^1.0"
+        "sfneal/queueables": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">=6.5.14",

--- a/src/MailCenter/SendMail.php
+++ b/src/MailCenter/SendMail.php
@@ -4,9 +4,9 @@ namespace Sfneal\PostOffice\MailCenter;
 
 use Illuminate\Mail\Mailable;
 use Illuminate\Support\Facades\Mail;
-use Sfneal\Queueables\AbstractJob;
+use Sfneal\Queueables\Job;
 
-class SendMail extends AbstractJob
+class SendMail extends Job
 {
     /**
      * @var string Queue to use


### PR DESCRIPTION
- cut support for php 7.0
- bump min sfneal/queueables version to ^2.0