### PR TITLE
Add config values & use in queueables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,3 +52,8 @@ All notable changes to `post-office` will be documented in this file
 - bump min sfneal/users dev requirement to v0.11.3
 - make ServiceProvider that publishes config files & views
 - make test suite for testing Mailables, Notifications & SendMail jobs
+
+
+## 0.8.0 - 2021-05-04
+- add 'queue' & 'driver' keys to post-office config
+- add use of 'post-office.queue' & 'post-office.driver' queue values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ All notable changes to `post-office` will be documented in this file
 - make test suite for testing Mailables, Notifications & SendMail jobs
 
 
-## 0.8.0 - 2021-05-04
+## 0.7.1 - 2021-05-04
 - add 'queue' & 'driver' keys to post-office config
 - add use of 'post-office.queue' & 'post-office.driver' queue values 
 - fix `PostOfficeServiceProvider` view publishing paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,4 +56,5 @@ All notable changes to `post-office` will be documented in this file
 
 ## 0.8.0 - 2021-05-04
 - add 'queue' & 'driver' keys to post-office config
-- add use of 'post-office.queue' & 'post-office.driver' queue values
+- add use of 'post-office.queue' & 'post-office.driver' queue values 
+- fix `PostOfficeServiceProvider` view publishing paths

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
             "role": "Developer"
         }
     ],
-    "version": "0.7.0",
+    "version": "0.7.1",
     "require": {
         "php": ">=7.4",
         "illuminate/support": "*",

--- a/config/post-office.php
+++ b/config/post-office.php
@@ -1,5 +1,27 @@
 <?php
 
 return [
+    /*
+    |--------------------------------------------------------------------------
+    | PostOffice Jobs Queue
+    |--------------------------------------------------------------------------
+    |
+    | Specify a Job queue to use when dispatching PostOffice jobs.  Creating a
+    | 'mail' queue can be effective for avoiding bottlenecks.
+    |
+    | type     : string
+    | default  : 'default'
+    |
+    */
+    'queue' => env('POST_OFFICE_QUEUE', 'default'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | PostOffice Queue Driver
+    |--------------------------------------------------------------------------
+    |
+    | Specify a Queue Driver for dispatching PostOffice jobs.
+    |
+    */
+    'driver' => env('POST_OFFICE_QUEUE_DRIVER', config('queue.default')),
 ];

--- a/src/MailCenter/SendMail.php
+++ b/src/MailCenter/SendMail.php
@@ -8,17 +8,6 @@ use Sfneal\Queueables\Job;
 
 class SendMail extends Job
 {
-    // todo: add use of config
-    /**
-     * @var string Queue to use
-     */
-    public $queue = 'mail';
-
-    /**
-     * @var string Queue connection to use
-     */
-    public $connection = 'database';
-
     /**
      * @var string Email address of recipient
      */
@@ -46,6 +35,9 @@ class SendMail extends Job
         $this->to = $to;
         $this->mailable = $mailable;
         $this->cc = $cc;
+
+        $this->onQueue(config('post-office.queue'));
+        $this->onConnection(config('post-office.driver'));
     }
 
     /**

--- a/src/Mailables/AbstractMailable.php
+++ b/src/Mailables/AbstractMailable.php
@@ -10,6 +10,7 @@ abstract class AbstractMailable extends BaseMailable
 {
     // todo: refactor to allow interfaces to set properties without passing to constructor
     // todo: refactor to use basic mailable building instead of views (new class?)
+    // todo: add use of config for setting default view
     use Queueable, SerializesModels;
 
     /**

--- a/src/Mailables/AbstractMailable.php
+++ b/src/Mailables/AbstractMailable.php
@@ -66,9 +66,8 @@ abstract class AbstractMailable extends BaseMailable
         $this->call_to_action = $call_to_action ?? $this->call_to_action;
         $this->view = $view ?? $this->view;
 
-        // todo: use config values
-        $this->onQueue('mail');
-        $this->onConnection('database');
+        $this->onQueue(config('post-office.queue'));
+        $this->onConnection(config('post-office.driver'));
     }
 
     /**

--- a/src/Notifications/AbstractNotification.php
+++ b/src/Notifications/AbstractNotification.php
@@ -31,9 +31,8 @@ abstract class AbstractNotification extends Notification implements ShouldQueue
     public function __construct()
     {
         $this->via = $this->via ?? ['mail'];
-        // todo: add use of config
-        $this->onQueue('mail');
-        $this->onConnection('database');
+        $this->onQueue(config('post-office.queue'));
+        $this->onConnection(config('post-office.driver'));
     }
 
     /**

--- a/src/Providers/PostOfficeServiceProvider.php
+++ b/src/Providers/PostOfficeServiceProvider.php
@@ -23,7 +23,7 @@ class PostOfficeServiceProvider extends ServiceProvider
 
         // Publish Views
         $this->publishes([
-            __DIR__.'/../resources/views' => resource_path('views/vendor/sfneal/post-office'),
+            __DIR__.'/../../resources/views' => resource_path('views/vendor/sfneal/post-office'),
         ], 'views');
     }
 

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -9,4 +9,24 @@ class ConfigTest extends TestCase
     {
         $this->assertIsArray(config('post-office'));
     }
+
+    /** @test */
+    public function queue()
+    {
+        $expected = 'default';
+        $output = config('post-office.queue');
+
+        $this->assertIsString($output);
+        $this->assertSame($expected, $output);
+    }
+
+    /** @test */
+    public function driver()
+    {
+        $expected = config('queue.default');
+        $output = config('post-office.driver');
+
+        $this->assertIsString($output);
+        $this->assertSame($expected, $output);
+    }
 }


### PR DESCRIPTION
- add 'queue' & 'driver' keys to post-office config
- add use of 'post-office.queue' & 'post-office.driver' queue values 
- fix `PostOfficeServiceProvider` view publishing paths