### PR TITLE
Initial Production release (v1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,3 +77,10 @@ All notable changes to `post-office` will be documented in this file
 ## 0.8.0 - 2021-05-04
 - refactor `AbstractMailable` to `Mailable` 
 - refactor `AbstractNotification` to `Notification`
+
+
+## 1.0.0 - 2021-05-05
+- initial production release
+- add tests for testing 'post-office.mailables' & 'post-office.mailables.footer' config values
+- add `send()` & `sendNow()` methods to `Notification` so that notifications can be sent without importing the `Notification` facade
+- add usage instructions to the readme

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Email suite for Laravel applications with extended Mailable & Notification functionality
 
-
+![Post Office](https://banners.beyondco.de/PostOffice.png?theme=dark&packageManager=composer+require&packageName=sfneal%2Fpost-office&pattern=connections&style=style_1&description=Email+suite+for+Laravel+applications+with+extended+Mailable+%26+Notification+functionality&md=1&showWatermark=1&fontSize=150px&images=mail-open&widths=auto)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -26,8 +26,188 @@ php artisan vendor:publish --provider="Sfneal\PostOffice\Providers\PostOfficeSer
 
 ## Usage
 
+### Creating a `Mailable` & sending it using the `SendMail` job.
+First create a `Mailable` extension & implement applicable mailable interfaces.
 ``` php
-// Usage description here
+use Sfneal\PostOffice\Mailables\Interfaces\CallToAction;
+use Sfneal\PostOffice\Mailables\Interfaces\Email;
+use Sfneal\PostOffice\Mailables\Interfaces\Greeting;
+use Sfneal\PostOffice\Mailables\Interfaces\Message;
+use Sfneal\PostOffice\Mailables\Interfaces\Title;
+use Sfneal\PostOffice\Mailables\Mailable;
+use Sfneal\PostOffice\Mailables\Traits\UserMailable;
+use Sfneal\Users\Models\User;
+
+class InvoiceUnpaidMailable extends Mailable implements Greeting, Email, Title, Message, CallToAction
+{
+    /**
+     * @var User
+     */
+    private $user;
+
+    /**
+     * @var int
+     */
+    private $invoice_id;
+
+    /**
+     * InvoicePaidMailable constructor.
+     *
+     * @param User $user
+     * @param int $invoice_id
+     */
+    public function __construct(User $user, int $invoice_id)
+    {
+        $this->user = $user;
+        $this->invoice_id = $invoice_id;
+        parent::__construct(
+            $this->getGreeting(),
+            $this->getEmail(),
+            $this->getTitle(),
+            $this->getMessages(),
+            $this->getCallToAction()
+        );
+    }
+    
+    /**
+     * @return string First line of email
+     */
+    public function getGreeting(): string
+    {
+        return "Hi {$this->user->first_name}";
+    }
+
+    /**
+     * Email recipient.
+     *
+     * @return string
+     */
+    public function getEmail(): string
+    {
+        return $this->user->email;
+    }
+
+    /**
+     * Retrieve the Mailable's subject/title.
+     *
+     * @return string
+     */
+    public function getTitle(): string
+    {
+        return "Unpaid Invoice: #{$this->invoice_id}";
+    }
+
+    /**
+     * Retrieve an array of messages to include in a mailable.
+     *
+     * @return array
+     */
+    public function getMessages(): array
+    {
+        return [
+            'You have one or more unpaid invoices.  Please send use money asap!',
+            "If your invoice is not paid within 30 days we're going to send a team of ninja's to your last known location.",
+        ];
+    }
+
+    /**
+     * Call to Action button in the body of the email.
+     *
+     * @return array
+     */
+    public function getCallToAction(): array
+    {
+        return [
+            'url' => 'https://google.com',
+            'text' => 'Pay Invoice',
+        ];
+    }
+}
+```
+
+Next, instantiate your `Mailable` & pass it as the $mailable parameter to the `SendMail` job.  `SendMail` can be dispatched to the Job queue or executed synchronously. 
+``` php
+$mailable = new InvoiceUnpaidMailable($user, $invoice_id);
+
+// Dispatch SendMail job to the queue
+SendMail::dispatch($user->email, $mailable);
+
+// Execute the SendMail synchronously
+SendMail::dispatchSync($user->email, $mailable);
+
+// Execute the SendMail synchronously without using Queueable static methods
+$sent = (new SendMail($user->email, $mailable))->handle();
+```
+
+
+#### Creating a Notification & sending it using the `Notification` facade
+First create a `Notification` extension that defines your notification.
+
+``` php
+use Sfneal\PostOffice\Notifications\Notification;
+use Sfneal\Users\Models\User;
+
+class InvoiceUnpaidNotification extends Notification
+{
+    /**
+     * @var User
+     */
+    public $user;
+
+    /**
+     * @var int
+     */
+    public $invoice_id;
+
+    /**
+     * InvoicePaidMailable constructor.
+     *
+     * @param User $user
+     * @param int $invoice_id
+     */
+    public function __construct(User $user, int $invoice_id)
+    {
+        $this->user = $user;
+        $this->invoice_id = $invoice_id;
+        parent::__construct();
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param mixed $notifiable
+     * @return InvoiceUnpaidMailable
+     */
+    public function toMail($notifiable): InvoiceUnpaidMailable
+    {
+        return (new InvoiceUnpaidMailable($this->user, $this->invoice_id))->to($notifiable->email);
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param mixed $notifiable
+     * @return array
+     */
+    public function toArray($notifiable): array
+    {
+        return [
+            'user_id' => $this->user->getKey(),
+            'invoice_id' => $this->invoice_id,
+        ];
+    }
+}
+```
+
+Send the Notification using either the `send()` or `sendNow()` methods.
+``` php
+$notification = new InvoiceUnpaidNotification($user, $invoice_id);
+
+// Send using the Job queue
+$notification->send($user);
+
+// Send synchronously
+$notification->sendNow($user);
 ```
 
 ### Testing

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
             "role": "Developer"
         }
     ],
-    "version": "0.8.0",
+    "version": "1.0.0",
     "require": {
         "php": ">=7.4",
         "illuminate/support": "*",
@@ -26,7 +26,7 @@
         "phpunit/phpunit": ">=6.5.14",
         "scrutinizer/ocular": "^1.8",
         "sfneal/mock-models": "^0.5.0",
-        "sfneal/users": "^0.11.3"
+        "sfneal/users": ">=0.11.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Notifications/Notification.php
+++ b/src/Notifications/Notification.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
 use Sfneal\PostOffice\Mailables\Mailable;
 
 abstract class Notification extends \Illuminate\Notifications\Notification implements ShouldQueue
@@ -60,4 +61,24 @@ abstract class Notification extends \Illuminate\Notifications\Notification imple
      * @return array
      */
     abstract public function toArray($notifiable): array;
+
+    /**
+     * Send the Notification using the `Illuminate\Support\Facades\Notification` facade.
+     *
+     * @param Collection|array|mixed $notifiables
+     */
+    public function send($notifiables): void
+    {
+        \Illuminate\Support\Facades\Notification::send($notifiables, $this);
+    }
+
+    /**
+     * Send the Notification immediately using the `Illuminate\Support\Facades\Notification` facade.
+     *
+     * @param Collection|array|mixed $notifiables
+     */
+    public function sendNow($notifiables): void
+    {
+        \Illuminate\Support\Facades\Notification::sendNow($notifiables, $this);
+    }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -8,6 +8,8 @@ class ConfigTest extends TestCase
     public function config_is_accessible()
     {
         $this->assertIsArray(config('post-office'));
+        $this->assertIsArray(config('post-office.mailables'));
+        $this->assertIsArray(config('post-office.mailables.footer'));
     }
 
     /** @test */
@@ -25,6 +27,45 @@ class ConfigTest extends TestCase
     {
         $expected = config('queue.default');
         $output = config('post-office.driver');
+
+        $this->assertIsString($output);
+        $this->assertSame($expected, $output);
+    }
+
+    /** @test */
+    public function mailables_view()
+    {
+        $expected = 'post-office::email';
+        $output = config('post-office.mailables.view');
+
+        $this->assertIsString($output);
+        $this->assertSame($expected, $output);
+    }
+
+    /** @test */
+    public function mailables_footer_enabled()
+    {
+        $output = config('post-office.mailables.footer.enabled');
+
+        $this->assertIsBool($output);
+        $this->assertTrue($output);
+    }
+
+    /** @test */
+    public function mailables_footer_address()
+    {
+        $expected = '35 Main Street, Milford MA 01747';
+        $output = config('post-office.mailables.footer.address');
+
+        $this->assertIsString($output);
+        $this->assertSame($expected, $output);
+    }
+
+    /** @test */
+    public function mailables_footer_unsubscribe_route()
+    {
+        $expected = 'unsubscribe';
+        $output = config('post-office.mailables.footer.unsubscribe_route');
 
         $this->assertIsString($output);
         $this->assertSame($expected, $output);

--- a/tests/NotificationTest.php
+++ b/tests/NotificationTest.php
@@ -51,7 +51,16 @@ class NotificationTest extends TestCase
     /** @test */
     public function notification_was_sent()
     {
-        Notification::send($this->user, new InvoiceUnpaidNotification($this->user, $this->invoice_id));
+        (new InvoiceUnpaidNotification($this->user, $this->invoice_id))->send($this->user);
+        Notification::assertSentTo([$this->user], function (InvoiceUnpaidNotification $notification) {
+            return $notification->invoice_id == $this->invoice_id && $notification->user == $this->user;
+        });
+    }
+
+    /** @test */
+    public function notification_was_sent_now()
+    {
+        (new InvoiceUnpaidNotification($this->user, $this->invoice_id))->sendNow($this->user);
         Notification::assertSentTo([$this->user], function (InvoiceUnpaidNotification $notification) {
             return $notification->invoice_id == $this->invoice_id && $notification->user == $this->user;
         });


### PR DESCRIPTION
- initial production release
- add tests for testing 'post-office.mailables' & 'post-office.mailables.footer' config values
- add `send()` & `sendNow()` methods to `Notification` so that notifications can be sent without importing the `Notification` facade
- add usage instructions to the readme